### PR TITLE
Upgrade to RxJava3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.4.10'
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,14 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
-    compileSdkVersion 28
-
-
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "io.sellmair.rxlifecycle.example"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 
@@ -23,17 +21,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     implementation project(':lib')
     implementation "io.reactivex.rxjava2:rxjava:2.2.3"

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -10,9 +10,9 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
     }
 
     buildTypes {
@@ -21,9 +21,21 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.0'
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
@@ -33,6 +45,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     implementation project(':lib')
-    implementation "io.reactivex.rxjava2:rxjava:2.2.3"
-
+    implementation "io.reactivex.rxjava3:rxjava:3.0.7"
 }

--- a/example/src/main/java/io/sellmair/disposer/example/DummyNetwork.kt
+++ b/example/src/main/java/io/sellmair/disposer/example/DummyNetwork.kt
@@ -1,6 +1,6 @@
 package io.sellmair.disposer.example
 
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 
 object DummyNetwork {
     fun query(): Observable<String> = Observable.just("Hello")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 03 14:13:08 CET 2019
+#Sun Nov 08 15:16:59 KST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,6 +34,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -42,9 +43,21 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.0'
+
     implementation 'androidx.lifecycle:lifecycle-common:2.2.0'
     testImplementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
     testImplementation 'junit:junit:4.13'
@@ -52,7 +65,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "io.reactivex.rxjava2:rxjava:2.2.3"
+    implementation "io.reactivex.rxjava3:rxjava:3.0.7"
 }
 repositories {
     mavenCentral()

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -24,13 +24,11 @@ ext {
 }
 
 android {
-    compileSdkVersion 28
-
-
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 
@@ -44,15 +42,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {
-    implementation 'androidx.lifecycle:lifecycle-common:2.0.0'
-    testImplementation 'androidx.lifecycle:lifecycle-runtime:2.0.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'androidx.lifecycle:lifecycle-common:2.2.0'
+    testImplementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "io.reactivex.rxjava2:rxjava:2.2.3"

--- a/lib/src/main/java/io/sellmair/disposer/Disposer.kt
+++ b/lib/src/main/java/io/sellmair/disposer/Disposer.kt
@@ -2,8 +2,8 @@
 
 package io.sellmair.disposer
 
-import io.reactivex.*
-import io.reactivex.disposables.Disposable
+import io.reactivex.rxjava3.core.*
+import io.reactivex.rxjava3.disposables.Disposable
 import io.sellmair.disposer.internal.LockedDisposer
 
 

--- a/lib/src/main/java/io/sellmair/disposer/LifecycleDisposers.kt
+++ b/lib/src/main/java/io/sellmair/disposer/LifecycleDisposers.kt
@@ -3,7 +3,6 @@
 package io.sellmair.disposer
 
 import androidx.lifecycle.Lifecycle
-import io.reactivex.disposables.Disposable
 
 /*
 ################################################################################################

--- a/lib/src/main/java/io/sellmair/disposer/internal/LockedDisposer.kt
+++ b/lib/src/main/java/io/sellmair/disposer/internal/LockedDisposer.kt
@@ -1,8 +1,7 @@
 package io.sellmair.disposer.internal
 
-import io.reactivex.*
-import io.reactivex.disposables.Disposable
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.core.*
+import io.reactivex.rxjava3.disposables.Disposable
 import io.sellmair.disposer.Disposer
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -45,7 +44,7 @@ internal class LockedDisposer : Disposer {
 
     override fun <T> bind(flowable: Flowable<T>): Flowable<T> {
         return flowable.doOnSubscribe { subscription ->
-            this += Disposables.fromSubscription(subscription)
+            this += Disposable.fromSubscription(subscription)
         }
     }
 

--- a/lib/src/test/java/io/sellmair/disposer/LifecycleDisposersTest.kt
+++ b/lib/src/test/java/io/sellmair/disposer/LifecycleDisposersTest.kt
@@ -2,9 +2,9 @@ package io.sellmair.disposer
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleRegistry
-import io.reactivex.Observable
-import io.reactivex.subjects.PublishSubject
-import io.reactivex.subjects.Subject
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.subjects.PublishSubject
+import io.reactivex.rxjava3.subjects.Subject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/lib/src/test/java/io/sellmair/disposer/LockedDisposerTest.kt
+++ b/lib/src/test/java/io/sellmair/disposer/LockedDisposerTest.kt
@@ -1,6 +1,6 @@
 package io.sellmair.disposer
 
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.disposables.Disposable
 import io.sellmair.disposer.internal.LockedDisposer
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -17,7 +17,7 @@ class LockedDisposerTest {
 
     @Test
     fun dispose_disposesSingleDisposable() {
-        val disposable = Disposables.empty()
+        val disposable = Disposable.empty()
         disposer.add(disposable)
 
         assertFalse(disposable.isDisposed)
@@ -28,7 +28,7 @@ class LockedDisposerTest {
 
     @Test
     fun dispose_disposesMultipleDisposables() {
-        val disposables = Array(12) { Disposables.empty() }
+        val disposables = Array(12) { Disposable.empty() }
         for (disposable in disposables) {
             disposer.add(disposable)
             assertFalse(disposable.isDisposed)

--- a/lib/src/test/java/io/sellmair/disposer/SlaveDisposerTest.kt
+++ b/lib/src/test/java/io/sellmair/disposer/SlaveDisposerTest.kt
@@ -1,6 +1,6 @@
 package io.sellmair.disposer
 
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.disposables.Disposable
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,7 +11,7 @@ class SlaveDisposerTest {
         val master = Disposer()
         val slave = Disposer(master)
 
-        val probe = Disposables.empty()
+        val probe = Disposable.empty()
         slave += probe
         master.dispose()
 
@@ -25,7 +25,7 @@ class SlaveDisposerTest {
         val slave = Disposer(master)
 
         repeat(10) {
-            val probe = Disposables.empty()
+            val probe = Disposable.empty()
             slave += probe
             assertFalse(probe.isDisposed)
 


### PR DESCRIPTION
You can see this information in RxJava github page.

> The 2.x version is in maintenance mode and will be supported only through bugfixes until February 28, 2021. No new features, behavior changes or documentation adjustments will be accepted or applied to 2.x.

So I create this PR.